### PR TITLE
Feed url changed

### DIFF
--- a/georss_qld_bushfire_alert_client/feed.py
+++ b/georss_qld_bushfire_alert_client/feed.py
@@ -8,7 +8,8 @@ from georss_client.feed import GeoRssFeed
 
 from .feed_entry import QldBushfireAlertFeedEntry
 
-URL: Final = "https://www.qfes.qld.gov.au/data/alerts/bushfireAlert.xml"
+# URL as published here: https://www.fire.qld.gov.au/Current-Incidents
+URL: Final = "https://publiccontent-gis-psba-qld-gov-au.s3.amazonaws.com/content/Feeds/BushfireCurrentIncidents/bushfireAlert.xml"
 
 
 class QldBushfireAlertFeed(GeoRssFeed):

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -23,8 +23,8 @@ def test_update_ok(mock_session, mock_request):
     feed = QldBushfireAlertFeed(HOME_COORDINATES)
     assert (
         repr(feed) == "<QldBushfireAlertFeed(home=(-31.0, 151.0), "
-        "url=https://www.qfes.qld.gov.au/data/alerts/"
-        "bushfireAlert.xml, radius=None, categories="
+        "url=https://publiccontent-gis-psba-qld-gov-au.s3.amazonaws.com/content/"
+        "Feeds/BushfireCurrentIncidents/bushfireAlert.xml, radius=None, categories="
         "None)>"
     )
     status, entries = feed.update()

--- a/tests/test_feed_manager.py
+++ b/tests/test_feed_manager.py
@@ -40,9 +40,8 @@ def test_feed_manager(mock_session, mock_request):
     assert (
         repr(feed_manager) == "<QldBushfireAlertFeedManager("
         "feed=<QldBushfireAlertFeed(home="
-        "(-31.0, 151.0), url=https://www."
-        "qfes.qld.gov.au/data/alerts/"
-        "bushfireAlert.xml, "
+        "(-31.0, 151.0), url=https://publiccontent-gis-psba-qld-gov-au.s3.amazonaws.com/"
+        "content/Feeds/BushfireCurrentIncidents/bushfireAlert.xml, "
         "radius=None, categories=None)>)>"
     )
     feed_manager.update()


### PR DESCRIPTION
fixes #29 

The URL published on the Queensland Fire Department website (https://www.fire.qld.gov.au/Current-Incidents) has changed. The old URL is working again, but appears to have slightly outdated information compared to this new one.